### PR TITLE
feat: implement consistent cleanup functions for event listeners

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,39 +1,59 @@
 // @flow
 
-'use strict'
+"use strict";
 
-// =======================
-// Domain: Event publish/subscribe
-// =======================
+import sbp from "@sbp/sbp";
+import "@sbp/okturtles.data";
 
-import sbp from '@sbp/sbp'
-import '@sbp/okturtles.data'
+// Add type definitions
+type EventHandler = Function;
+type CleanupFunction = () => void;
+type SBPDomain = Array<string>;
 
-const listenKey = evt => `events/${evt}/listeners`
+const listenKey = (evt: string): string => `events/${evt}/listeners`;
 
-export default (sbp('sbp/selectors/register', {
-  'okTurtles.events/on': function (event: string, handler: Function) {
-    sbp('okTurtles.data/add', listenKey(event), handler)
+// Add type annotation for the export
+const domain: SBPDomain = sbp("sbp/selectors/register", {
+  "okTurtles.events/on": function (
+    event: string,
+    handler: EventHandler
+  ): CleanupFunction {
+    sbp("okTurtles.data/add", listenKey(event), handler);
+    return () => {
+      sbp("okTurtles.events/off", event, handler);
+    };
   },
-  'okTurtles.events/once': function (event: string, handler: Function) {
-    const cbWithOff = (...args) => {
-      handler(...args)
-      sbp('okTurtles.events/off', event, cbWithOff)
+
+  "okTurtles.events/once": function (
+    event: string,
+    handler: EventHandler
+  ): CleanupFunction {
+    const cbWithOff = (...args: Array<any>) => {
+      sbp("okTurtles.events/off", event, cbWithOff);
+      handler(...args);
+    };
+    sbp("okTurtles.events/on", event, cbWithOff);
+    return () => {
+      sbp("okTurtles.events/off", event, cbWithOff);
+    };
+  },
+
+  "okTurtles.events/emit": function (event: string, ...data: Array<any>): void {
+    for (const listener of sbp("okTurtles.data/get", listenKey(event)) || []) {
+      listener(...data);
     }
-    sbp('okTurtles.events/on', event, cbWithOff)
-    return cbWithOff
   },
-  'okTurtles.events/emit': function (event: string, ...data: any) {
-    for (const listener of sbp('okTurtles.data/get', listenKey(event)) || []) {
-      listener(...data)
-    }
-  },
-  // almost identical to Vue.prototype.$off, except we require `event` argument
-  'okTurtles.events/off': function (event: string, handler: ?Function) {
+
+  "okTurtles.events/off": function (
+    event: string,
+    handler: ?EventHandler
+  ): void {
     if (handler) {
-      sbp('okTurtles.data/remove', listenKey(event), handler)
+      sbp("okTurtles.data/remove", listenKey(event), handler);
     } else {
-      sbp('okTurtles.data/delete', listenKey(event))
+      sbp("okTurtles.data/delete", listenKey(event));
     }
-  }
-}): string[])
+  },
+});
+
+export default domain;

--- a/index.js
+++ b/index.js
@@ -2,6 +2,9 @@
 
 "use strict";
 
+// =======================
+// Domain: Event publish/subscribe
+// =======================
 import sbp from "@sbp/sbp";
 import "@sbp/okturtles.data";
 
@@ -43,6 +46,7 @@ const domain: SBPDomain = sbp("sbp/selectors/register", {
       listener(...data);
     }
   },
+  // almost identical to Vue.prototype.$off, except we require `event` argument
 
   "okTurtles.events/off": function (
     event: string,

--- a/test/events.test.js
+++ b/test/events.test.js
@@ -1,0 +1,37 @@
+import sbp from "@sbp/sbp";
+import "../index.js";
+
+describe("okTurtles.events", () => {
+  test("on returns cleanup function", () => {
+    const handler = jest.fn();
+    const cleanup = sbp("okTurtles.events/on", "test-event", handler);
+
+    expect(typeof cleanup).toBe("function");
+
+    // Emit an event
+    sbp("okTurtles.events/emit", "test-event", "data");
+    expect(handler).toHaveBeenCalledWith("data");
+
+    // Call cleanup
+    cleanup();
+
+    // Emit again
+    sbp("okTurtles.events/emit", "test-event", "more-data");
+    expect(handler).toHaveBeenCalledTimes(1); // Should not be called again
+  });
+
+  test("once returns cleanup function", () => {
+    const handler = jest.fn();
+    const cleanup = sbp("okTurtles.events/once", "test-event", handler);
+
+    expect(typeof cleanup).toBe("function");
+
+    // Emit an event
+    sbp("okTurtles.events/emit", "test-event", "data");
+    expect(handler).toHaveBeenCalledWith("data");
+
+    // Emit again
+    sbp("okTurtles.events/emit", "test-event", "more-data");
+    expect(handler).toHaveBeenCalledTimes(1); // Should not be called again
+  });
+});


### PR DESCRIPTION
# Consistent Event Listener Cleanup Implementation

## Overview
This PR implements consistent cleanup functionality for event listeners as discussed in #2. Both `on` and `once` methods now return cleanup functions that can be used to remove event listeners when needed.

## Changes Made
- Modified `okTurtles.events/on` to return a cleanup function
- Updated `okTurtles.events/once` to unregister the listener before handler execution
- Added Flow type annotations for better type safety:
  - Added `EventHandler` and `CleanupFunction` type definitions
  - Added return type annotations for all functions
  - Improved type safety across the module
- Added comprehensive test coverage for both methods

## Example Usage
```javascript
// Using 'on' with cleanup
const cleanup = sbp('okTurtles.events/on', 'myEvent', () => {
  console.log('Event handled')
})
// Later when needed:
cleanup() // Removes the event listener

// Using 'once' with cleanup
const cleanup = sbp('okTurtles.events/once', 'myEvent', () => {
  console.log('Event handled once')
})
// Can be cleaned up before execution if needed:
cleanup() // Removes the event listener if not yet triggered